### PR TITLE
Exclude Puerto Rico from active case count

### DIFF
--- a/src/pages/GraphPage/allCountriesGraph.js
+++ b/src/pages/GraphPage/allCountriesGraph.js
@@ -23,9 +23,6 @@ export default class AllCountriesGraph extends Component {
   }
   
   componentDidMount(){
-
-    console.log(!!this.state.data[0] ? this.state.data[0]["name"] : "");
-    console.log(this.state.data);
     this.setState({data: this.props.countryData[0]})
   }
 


### PR DESCRIPTION
Recovery data is currently not available for Puerto Rico, which makes it impossible to calculate the active cases for Puerto Rico. As such, all their confirmed cases were included in the overall active case count which it not accurate. At this point it is better to exclude Puerto Rico's data all together.