### PR TITLE
changed dismiss to 'x' - fixed the issue #5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,9 +3133,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001036",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
-      "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
+      "version": "1.0.30001146",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz",
+      "integrity": "sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/pages/MapPage/Map.js
+++ b/src/pages/MapPage/Map.js
@@ -36,7 +36,8 @@ const cardStyle = {
 const dismissMessageStyle = {
   color: "white",
   fontSize: "11px",
-  textDecoration: "underline",
+  textDecoration: "none",
+  cursor: "pointer",
   bordersize: "1px",
   borderColor: "white",
   marginTop: "0px",
@@ -309,7 +310,7 @@ export default class Map extends Component {
               >
                 <Card.Body>
                   <Card.Text style={cardTextStyle}>
-                    <div style={dismissMessageStyle} onClick={this.onClickHideLowest}>dismiss</div>
+                    <div style={dismissMessageStyle} onClick={this.onClickHideLowest}>x</div>
                     <AccordionToggle eventKey="1" style={cardTextStyle}>Lowest Active Cases</AccordionToggle>
                     <Accordion.Collapse eventKey="1">
                       <div style={{ fontSize: 12 }}>
@@ -336,7 +337,7 @@ export default class Map extends Component {
                 >
                   <Card.Body>
                     <Card.Text style={cardTextStyle}>
-                      <div style={dismissMessageStyle} onClick={this.onClickHideHighest}>dismiss</div>
+                      <div style={dismissMessageStyle} onClick={this.onClickHideHighest}>x</div>
                       <AccordionToggle eventKey="1" style={cardTextStyle}>Highest Active Cases</AccordionToggle>
                       <Accordion.Collapse eventKey="1">
                         <div style={{ fontSize: 12 }}>


### PR DESCRIPTION
I have fixed the issue #5. The "dismiss" is replaced with "x". Also the underline has gone and instead of cursor I changed it to a hand pointer which is most suitable here. 

![1](https://user-images.githubusercontent.com/37333830/95648494-47a20d80-0af5-11eb-897c-70803de3dc6c.JPG)
